### PR TITLE
Fix workflows | Changed the release creation event

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -21,7 +21,7 @@ jobs:
       run: |
         mkdir $RELEASE_DIR
         docker run --rm -v $(pwd):/workdir -e CROSS_TRIPLE=$OS multiarch/crossbuild gcc vcd.c -o $RELEASE_DIR/vcd-$OS
-        ls -a build
+        ls -a $RELEASE_DIR
     - name: publish
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,6 +1,10 @@
-name: push
+name: push to master
 
-on: [push]
+on:
+  push:
+    branches:
+    - 'master'
+    
 jobs:
   build:
     strategy:


### PR DESCRIPTION
Good afternoon.
It seems to me wrong to provide the user with binary versions of programs from unstable branches. As a result, confusion may arise. As well as work on new versions can damage the stable release of this day.
P.S. I apologize for missed this nuance in the previous PR. 